### PR TITLE
feat: added 'dmark list' command

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dmark",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Terraform wrapper for multi-stage and multi-stack which only add a config file. Perfect for no HCP projects.",
   "main": "src/index.js",
   "types": "./types/**/*.d.ts",


### PR DESCRIPTION
With this PR is possible to call the command:
```sh
pnpm dmark list
```
or
```sh
pnpm dmark list --config ./config/dmark.config.yaml
```
The output should look like this:
```sh
-------------------------------------------------------------------------- 
List of all possible plan commands to be called with this project config:
--------------------------------------------------------------------------
dmark plan --stack testStack --stage dev
dmark plan --stack testStack --stage staging
dmark plan --stack testStack --stage prod
--------------------------------------------------------------------------
List of all possible apply commands to be called with this project config:
--------------------------------------------------------------------------
dmark apply --stack testStack --stage dev
dmark apply --stack testStack --stage staging
dmark apply --stack testStack --stage prod
```